### PR TITLE
Add minimal trigger for issue #22867 repro

### DIFF
--- a/issue-22867/README.md
+++ b/issue-22867/README.md
@@ -17,8 +17,9 @@ repo/
         └── rule-test.ts
 ```
 
-The nested config extends `../../node_modules/@byted-image/oxlint/configs/ts.json`,
-and that extended config enables `oxc/no-const-enum`.
+The nested config extends `../../node_modules/@byted-image/oxlint/configs/ts.json`.
+That extended config enables `oxc/no-const-enum` and contains
+`plugins: ["typescript"]`.
 
 Source:
 
@@ -38,6 +39,8 @@ cd packages/lv-infra-plugins && npx oxlint@1.67.0 rule-test.ts --format json
 npx oxlint@1.67.0 -c packages/lv-infra-plugins/.oxlintrc.json packages/lv-infra-plugins/rule-test.ts --format json
 ```
 
-Observed locally with `oxlint@1.67.0`: all three commands report
-`oxc(no-const-enum)`, so the minimal setup does not reproduce the root CLI
-miss described in the issue.
+Observed locally with `oxlint@1.67.0`: the root command misses
+`oxc(no-const-enum)`, while the package-directory command and explicit-config
+command report it. If `plugins: ["typescript"]` is removed from `ts.json`, the
+root command starts reporting `oxc(no-const-enum)`, so that field is the minimal
+trigger missing from the earlier reduced example.

--- a/issue-22867/node_modules/@byted-image/oxlint/configs/ts.json
+++ b/issue-22867/node_modules/@byted-image/oxlint/configs/ts.json
@@ -1,4 +1,7 @@
 {
+  "plugins": [
+    "typescript"
+  ],
   "rules": {
     "oxc/no-const-enum": "error"
   }


### PR DESCRIPTION
This updates the existing #22867 repro with the minimal missing trigger.

The only behavior-changing difference is adding `plugins: ["typescript"]` to the extended config.

Verified with `oxlint@1.67.0`:

- root invocation misses `oxc(no-const-enum)` and exits 0
- package-cwd invocation reports `oxc(no-const-enum)` and exits 1
- root invocation with explicit `-c` reports `oxc(no-const-enum)` and exits 1

Removing `plugins: ["typescript"]` makes the root invocation report `oxc(no-const-enum)` again.
